### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=0.1.0
 author=cs_suncc
 maintainer=cs_suncc
 sentence=Full Arduino Library for LCD1602
+paragraph=LCD1602 is a series of HD44780 compatible LCD module.
 category=Communication
 url=https://github.com/cs-suncc/LCD1602
 architectures=*


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format